### PR TITLE
Add Co-Developer GPT engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ _Updated on January 26, 2024_ (A total of 1387 repositories listed.)
  * [CodeGPT](https://github.com/carlrobertoh/codegpt) - JetBrains extension providing access to state-of-the-art LLMs, such as GPT-4, Code Llama, and others, all for free
  * [ReadSomething](https://github.com/readsomething/readsomething) - 📖 一个开源的 Chrome 插件，可以将网页转成阅读模式，并且内置了 AI 总结、翻译、Markdown 转换等功能。
  * [writely](https://github.com/anc95/writely) - ❤️‍🔥 A chrome extension as an alternative to Notion AI that goes beyond Notion AI. | 一个替代 Notion AI 的浏览器插件，不止于 Notion AI
+ * [Co-Developer GPT engine](https://github.com/stoerr/CoDeveloperGPTengine) - provides local r/w file access from ChatGPT chat as GPT actions or ChatGPT plugin, incl. execution of configured actions on your own machine.
 
 
 ## CLIs


### PR DESCRIPTION
The free Co-Developer GPT engine serves in OpenAI GPTs and as ChatGPT plugin to give ChatGPT in the chat the ability to modify the files in the directory it is started in, and thus makes it possible to discuss code without copying and pasting it there, and to let ChatGPT write code / modify, even run build actions fixing problems until they work.

https://CoDeveloperGPTengine.stoerr.net/ 
https://github.com/stoerr/CoDeveloperGPTengine 
https://www.youtube.com/watch?v=ubBhv2PUSEs 

Language: Java
Licence:  Apache-2.0