### PR TITLE
Add MeterCall (new-layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2626,4 +2626,4 @@ _Updated on April 15, 2026_ (A total of 2512 repositories listed.)
  * [cchub](https://github.com/moresl/cchub) - CCHub - Claude Code 生态管理平台 | Claude Code Ecosystem Management Platform (MCP, Skills, Hooks, Config)
  * [nothumansearch](https://github.com/unitedideas/nothumansearch) - Search engine for AI agent tools. Indexes MCP servers and AI-ready APIs with agentic readiness scoring. REST API and MCP server.
 
-
+- [MeterCall](https://metercall.ai/?v=a&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** The new layer of the internet. 21M APIs. 727 modules. One prompt.
- **URL:** https://metercall.ai/?v=a&src=github
- **Why it belongs here:** A curated list of resources dedicated to open source GitHub repositories related to ChatGPT, OpenAI API, and Codex

Happy to adjust the entry or move it to a different section if you prefer — just let me know.