### PR TITLE
Add awesome-ai-startups to Awesome-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ _Updated on May 07, 2026_ (A total of 2554 repositories listed.)
  * ✅ [Awesome-ChatGPT-Prompts-CN](https://github.com/wikieden/awesome-chatgpt-prompts-cn) - ⭐ 1.3k / ChatGPT调教指南|咒语指南|聊天提示词指南|学习指南
  * 🔥 [Awesome-GPT-Image-2-API-Prompts](https://github.com/anil-matcha/awesome-gpt-image-2-api-prompts) - ⭐ 1.7k / Curated GPT-Image-2 prompts for the OpenAI API — portraits, posters, UI mockups, game screenshots, character sheets, and more. Ready-to-use prompts for gpt-image-2.
  * [awesome-gpt-image-2-prompts](https://github.com/evolinkai/awesome-gpt-image-2-prompts) - Curated GPT-Image-2 prompts fot the Openai API：image examples across portraits, posters, UI mockups, character sheets, and community experiments.
+ * [awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.
 
 
 ## Prompts


### PR DESCRIPTION
Adds [awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) to the Awesome-lists section — a curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.

Per contributing.md, this PR uses the simple link format and only modifies README.md; the maintainer can apply the star badge / JSON entry as usual.