### PR TITLE
Add openclaw-easy-desktop to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ _Updated on May 11, 2026_ (A total of 2565 repositories listed.)
  * [ruflo](https://github.com/ruvnet/ruflo) - Codex Integration
  * [evolution-api](https://github.com/evolution-foundation/evolution-api) - Evolution API is an open-source WhatsApp integration API
  * [agor](https://github.com/preset-io/agor) - Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas. Manage git worktrees, track AI conversations, and visualize your team's agentic work in real-time.
+ * [openclaw-easy-desktop](https://github.com/openclaw-easy/openclaw-easy-desktop) - One-click signed desktop installer (macOS + Windows) for OpenClaw — connects WhatsApp, Telegram, Slack, Discord, Feishu and Line to ChatGPT, Claude, Gemini, DeepSeek, OpenRouter or local Ollama models with 100% local execution.
 
 
 ## Browser-extensions


### PR DESCRIPTION
Adds OpenClaw Easy to **Chatbots**.

**What it does**

One-click signed desktop installer (macOS + Windows) for OpenClaw — pipes ChatGPT (and Claude, Gemini, DeepSeek, OpenRouter, or local Ollama models) into WhatsApp, Telegram, Slack, Discord, Feishu and Line. 100% local execution; encrypted credential storage on the user's machine.

**Compliance checklist**

- [x] Format: \`* [project-name](url) - description ending with period.\`
- [x] Added to Chatbots section
- [x] ChatGPT/OpenAI API support is first-class (in addition to other providers)
- [x] Open source (Apache-2.0)
- [x] Maintainer will apply table entry per CONTRIBUTING (only adding the bullet)

Project: https://github.com/openclaw-easy/openclaw-easy-desktop
Website: https://openclaw-easy.com
