### PR TITLE
Add dakera-mcp: self-hosted MCP-native persistent memory for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ _Updated on May 11, 2026_ (A total of 2565 repositories listed.)
  * ✅ [Awesome-GPT-Image-2-API-Prompts](https://github.com/anil-matcha/awesome-gpt-image-2-api-prompts) - ⭐ 1.9k / Curated GPT-Image-2 prompts for the OpenAI API — portraits, posters, UI mockups, game screenshots, character sheets, and more. Ready-to-use prompts for gpt-image-2.
  * 🔥 [awesome-gpt-image-2-prompts](https://github.com/evolinkai/awesome-gpt-image-2-prompts) - ⭐ 14k / Curated GPT-Image-2 prompts fot the Openai API：image examples across portraits, posters, UI mockups, character sheets, and community experiments.
  * [awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only.
+ * [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP-native persistent memory server for AI agents. Decay-weighted retrieval, HNSW vector search, RocksDB storage, and multi-agent namespacing.
 
 
 ## Prompts


### PR DESCRIPTION
## What

Adds [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) to the **Others** section.

## Why

Dakera is a self-hosted, MCP-native persistent memory server for AI agents and LLM applications. It provides decay-weighted memory retrieval, HNSW vector search, RocksDB-backed storage, and multi-agent namespacing. It addresses the growing need for production-grade agent memory infrastructure that integrates with ChatGPT and other LLM tools via the Model Context Protocol.

The entry follows the existing format in the Others section (bullet with link and short description, no star badge for new entries without established star count).

## Entry added

```
 * [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP-native persistent memory server for AI agents. Decay-weighted retrieval, HNSW vector search, RocksDB storage, and multi-agent namespacing.
```