### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,7 @@ _Updated on May 20, 2026_ (A total of 2582 repositories listed.)
 
 ## Tutorials
 
+ * [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
  * 💤 [Hello-Python](https://github.com/mouredev/hello-python) - ⭐ 36k / Curso para aprender el lenguaje de programación Python desde cero y para principiantes. Más de 30 clases, 25 horas en vídeo, código y grupo de chat. Desde sus fundamentos hasta la creación de un API Backend con base de datos y más...
  * ⚠️ [notebooks](https://github.com/dataflowr/notebooks) - ⭐ 1.3k / code for deep learning courses
  * 💤 [gpt4all-colab](https://github.com/camenduru/gpt4all-colab) - ⭐ 102 / 🔥gpt4all (the best chatgpt clone) running locally and on colab tutorial -  -  to @camenduru's colab -
@@ -1876,7 +1877,8 @@ _Updated on May 20, 2026_ (A total of 2582 repositories listed.)
  * ⚠️ [autoview](https://github.com/wrtnlabs/autoview) - ⭐ repo not found / Automatic view component renderer by AI agent
  * 🔥 [helix](https://github.com/helixml/helix) - ⭐ 774 / ♾️ Helix is a private GenAI stack for building AI applications with declarative pipelines, knowledge (RAG), API bindings, and first-class testing.
  * 🔥 [openinference](https://github.com/arize-ai/openinference) - ⭐ 959 / OpenTelemetry Instrumentation for AI Observability
- * 💤 [WorkflowAI](https://github.com/workflowai/workflowai) - ⭐ 471 / WorkflowAI is an open-source platform where product and engineering teams  collaborate to build and iterate on AI features.
+ * 💤 [WorkflowAI](https://github.com/workflowai/workflowai) - ⭐ 471 / WorkflowAI is an open-source platform where product and engineering teams 
+collaborate to build and iterate on AI features.
  * 🔥 [company-research-agent](https://github.com/guy-hartstein/company-research-agent) - ⭐ 1.9k / An agentic company research tool powered by LangGraph and Tavily that conducts deep diligence on companies using a multi-agent framework. It leverages Google's Gemini 2.0 Flash and OpenAI's GPT-4.1 on the backend for inference.
  * ⚠️ [zen-mcp-server](https://github.com/beehiveinnovations/zen-mcp-server) - ⭐ 12k / All Of The Above] working as one.
  * 💤 [llm-ui](https://github.com/richardgill/llm-ui) - ⭐ 1.7k / The React library for LLMs

--- a/README.md
+++ b/README.md
@@ -1295,7 +1295,7 @@ _Updated on May 20, 2026_ (A total of 2582 repositories listed.)
 
 ## Tutorials
 
- * [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+ * [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/chatgpt-applications) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
  * 💤 [Hello-Python](https://github.com/mouredev/hello-python) - ⭐ 36k / Curso para aprender el lenguaje de programación Python desde cero y para principiantes. Más de 30 clases, 25 horas en vídeo, código y grupo de chat. Desde sus fundamentos hasta la creación de un API Backend con base de datos y más...
  * ⚠️ [notebooks](https://github.com/dataflowr/notebooks) - ⭐ 1.3k / code for deep learning courses
  * 💤 [gpt4all-colab](https://github.com/camenduru/gpt4all-colab) - ⭐ 102 / 🔥gpt4all (the best chatgpt clone) running locally and on colab tutorial -  -  to @camenduru's colab -


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/chatgpt-applications) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/chatgpt-applications) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.