### PR TITLE
Add eval-harness — behavior-regression testing for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2734,5 +2734,6 @@ _Updated on May 31, 2026_ (A total of 2598 repositories listed.)
  * [takt](https://github.com/nrslib/takt) - TAKT Agent Koordination Topology - Define how AI agents coordinate, where humans intervene, and what gets recorded — in YAML
  * [ccx](https://github.com/benedictking/ccx) - Gemini API Proxy - CCX
  * [helmor](https://github.com/dohooo/helmor) - Open-source local workbench for multi-agent software development.
+ * [eval-harness](https://github.com/nano-step/eval-harness) - Behavior-regression testing for LLM agents. 4-class attribution, 6-field FAIL schema, $-cost gating, flaky detection. Bash + jq, MIT.
 
 


### PR DESCRIPTION
## What

Adds [eval-harness](https://github.com/nano-step/eval-harness) to the **Others** section.

## Why

eval-harness is a focused behavior-regression testing harness for LLM agents (Anthropic Claude via opencode today; LangGraph and Claude-Agent-SDK runners on the roadmap). It detects when an agent's behavior drifts from a baseline, attributes the cause across 4 deterministic classes (`SKILL_CHANGED` / `FIXTURE_STALE` / `MODEL_CHANGED` / `UNKNOWN_DRIFT`), and emits a 6-field FAIL schema including `transcript_span` and `env_delta`.

Ships a composite GitHub Action and a git pre-push hook. Bash + jq + python3 stdlib, no daemon, MIT.

## Project hygiene

- v0.4.2 released 2026-05-30 (closes 8 audit-surfaced BLOCKERs)
- 20/20 test suites green on `main`
- CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md present
- Active maintenance with `good first issue` + `help wanted` issues open for contributors

## Compliance with contributing.md

- [x] Format: `* [name](url) - description ending with period.`
- [x] Description concise
- [x] Added to README.md only
- [x] Placed in Others (no Testing/Evaluation section exists)

Thanks for maintaining this list.