### PR TITLE
Add NarraNexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2764,5 +2764,6 @@ _Updated on June 15, 2026_ (A total of 2614 repositories listed.)
  * [helmor](https://github.com/dohooo/helmor) - Open-source local workbench for multi-agent software development.
  * [evo](https://github.com/evo-hq/evo) - turns your codebase into an autoresearch loop — discovers what to measure, instruments the benchmark, then runs tree search with parallel subagents.
  * [lottie](https://github.com/diffusionstudio/lottie) - Generate production-ready Lottie animations with Claude Code or Codex
+ * [NarraNexus](https://github.com/NetMindAI-Open/NarraNexus) - Open-source AI agent team workspace by NetMind.AI. Agents remember, collaborate, and use tools from day one with persistent memory, multi-agent collaboration (PM/dev/deployment/research), and MCP-style tool integrations.
 
 


### PR DESCRIPTION
NarraNexus is an open-source AI agent team workspace by NetMind.AI. Agents remember, collaborate, and use tools from day one — with persistent memory across sessions, multi-agent collaboration (PM/dev/deployment/research agents), and MCP-style tool integrations.

GitHub: https://github.com/NetMindAI-Open/NarraNexus