### PR TITLE
feat: add NotFair — Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2769,3 +2769,4 @@ _Updated on June 15, 2026_ (A total of 2614 repositories listed.)
 
 
  * [superhighway-examples](https://github.com/patwalls/superhighway-examples) - Runnable Python examples for the Superhighway web search API using the OpenAI API — a news briefing agent, a web search CLI, and a scrape-and-analyze tool.
+ * [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code skills for marketing work (SEO, GEO, Google Ads, and Meta Ads). It has ~2.9k stars on GitHub and is MIT-licensed.

What it does: NotFair gives Claude Code agent skills that connect to live ad and analytics data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so you can run audits, fix keyword waste, and analyze organic performance directly from your terminal.

I placed it in the Others section alongside other Claude Code / agent skill projects (like `skill.color-expert` and `suppr-skills`). Happy to move it or adjust the description if you'd prefer a different spot or wording.

Thanks again!