### PR TITLE
Add LoopTroop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2770,3 +2770,4 @@ _Updated on June 15, 2026_ (A total of 2614 repositories listed.)
 
  * [superhighway-examples](https://github.com/patwalls/superhighway-examples) - Runnable Python examples for the Superhighway web search API using the OpenAI API — a news briefing agent, a web search CLI, and a scrape-and-analyze tool.
  * [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+ * [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local, open-source GUI that orchestrates AI coding agents from ticket to PR, with LLM-council planning, isolated git worktrees, and a Ralph loop that retries on failure. Built on OpenCode.


### PR DESCRIPTION
I added LoopTroop as a single entry at the end of the list.

It's a local, open-source GUI I've been building that orchestrates AI coding agents from a ticket through to a reviewable PR. An LLM council plans the work, tasks run in isolated git worktrees, and a Ralph loop resets the worktree and retries from clean context when a run goes wrong. It's built on OpenCode and works with the usual models including the OpenAI ones.

One line, matching the existing format in README.md.

Repo: https://github.com/looptroop-ai/LoopTroop