### PR TITLE
Remove stale duplicate gptme entry (erikbjare/gptme → gptme/gptme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,7 +1134,6 @@ _Updated on June 28, 2026_ (A total of 2640 repositories listed.)
  * 💤 [ChatGPTCLIBot](https://github.com/lagpixellol/chatgptclibot) - ⭐ 339 / ChatGPT Bot in CLI with long term memory support using Embeddings.
  * 💤 [openai4j](https://github.com/lambdua/openai4j) - ⭐ 385 / Java client library for OpenAI API.Full support for all OpenAI API models including Completions, Chat, Edits, Embeddings, Audio, Files, Assistants-v2, Images, Moderations, Batch, and Fine-tuning.
  * 💤 [json-translator](https://github.com/mololab/json-translator) - ⭐ 609 / Argos
- * 🔥 [gptme](https://github.com/erikbjare/gptme) - ⭐ 4.3k / Chat with LLMs equipped with local tools: executes python and bash, edits local files, browses the web.
  * ⚠️ [Apt](https://github.com/rnchg/apt) - ⭐ 775 / AI Productivity Tool - Free and open-source, enhancing user productivity while ensuring privacy and data security. It provides efficient and convenient AI solutions, including but not limited to: built-in exclusive ChatGPT, one-click batch intelligent processing of images and videos, and more.
  * 🔥 [chatgpt-subtitle-translator](https://github.com/cerlancism/chatgpt-subtitle-translator) - ⭐ 379 / Efficient translation tool based on ChatGPT API
  * 🔥 [tenere](https://github.com/pythops/tenere) - ⭐ 662 / 🔥 TUI interface for LLMs written in Rust


### PR DESCRIPTION
The list has two entries for the same project:

- `github.com/erikbjare/gptme` — old URL, now a redirect, with an outdated description
- `github.com/gptme/gptme` — canonical org repo, current description

`erikbjare/gptme` permanently redirects to `gptme/gptme` (the project moved to its own org), so the two rows point at the same repository. This removes the stale `erikbjare/gptme` row and keeps the canonical `gptme/gptme` entry with the up-to-date description.

Verified: `GET /repos/erikbjare/gptme` resolves to `full_name: gptme/gptme`.