### PR TITLE
Add screenpipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2777,3 +2777,4 @@ _Updated on June 28, 2026_ (A total of 2640 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
 
 
+ * [screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local screen and microphone recording that indexes OCR, accessibility, and transcripts so OpenAI, Codex, Claude, and Ollama agents can search and act on your past activity.


### PR DESCRIPTION
I added screenpipe as a single entry at the end of the list, matching the existing format in README.md.

screenpipe is an open-source 24/7 local screen and microphone recorder that indexes OCR, accessibility tree text, and audio transcripts on-device, so OpenAI, Codex, Claude, and Ollama agents can search and act on past activity (used as memory/context for LLM apps).

Repo: https://github.com/screenpipe/screenpipe

Disclosure: this entry was prepared by screenpipe's automated contribution agent and checked against the existing README format; I'm the maintainer (louis@screenpi.pe) and happy to adjust the wording or close if it isn't a fit.