### PR TITLE
Add TweetClaw and remove duplicate CLI entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
 
 ## CLIs
 
+ * [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - OpenClaw plugin for X/Twitter search, reply search, follower exports, media workflows, monitors, webhooks, giveaways, and approval-reviewed post actions.
  * [ChatGPT](https://github.com/acheong08/chatgpt) - Reverse engineered ChatGPT API
  * [shell_gpt](https://github.com/ther1d/shell_gpt) - A command-line productivity tool powered by ChatGPT, will help you accomplish your tasks faster and more efficiently.
  * [PyChatGPT](https://github.com/rawandahmad698/pychatgpt) - ⚡️ Python client for the unofficial ChatGPT API with auto token regeneration, conversation tracking, proxy support and more.
@@ -1200,7 +1201,6 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [claude-context](https://github.com/zilliztech/claude-context) - MCP for code search, build for Claude Code, Gemini CLI or any code agents.
  * [gonzo](https://github.com/control-theory/gonzo) - Gonzo! The Go based TUI log analysis tool
  * [gcli2api](https://github.com/su-kaka/gcli2api) - 将 GeminiCLI 转换为 OpenAI 和 GEMINI API 接口
- * [nanocoder](https://github.com/mote-software/nanocoder) - A beautiful local-first coding agent running in your terminal - built by the community for the community ⚒
  * [snapai](https://github.com/betomoedano/snapai) - AI-powered icon generation CLI for React Native & Expo developers. Generate stunning app icons in seconds using OpenAI's latest models.
  * [sgpt](https://github.com/tbckr/sgpt) - SGPT is a command-line tool that provides a convenient way to interact with OpenAI models, enabling users to run queries, generate shell commands and produce code directly from the terminal.
  * [Conversation-Knowledge-Mining-Solution-Accelerator](https://github.com/microsoft/conversation-knowledge-mining-solution-accelerator) - ⚡ Microsoft Fabric CLI
@@ -1233,7 +1233,6 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [parllama](https://github.com/paulrobello/parllama) - TUI for Ollama and other LLM providers
  * [agents-radar](https://github.com/duanyytop/agents-radar) - Tracks Claude Code, Codex, Gemini CLI, OpenClaw ecosystem, GitHub AI trending, and Anthropic/OpenAI updates. Daily Chinese digests via GitHub Actions.
  * [nexu](https://github.com/nexu-io/nexu) - The simplest desktop client for OpenClaw 🦞 — bridge your Agent to WeChat, Feishu, Slack & Discord in one click. Works with Claude Code, Codex & any LLM. BYOK, Oauth, local-first, chat from your phone 24/7.
- * [forgecode](https://github.com/antinomyhq/forgecode) - AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models
  * [openclaude](https://github.com/gitlawb/openclaude) - Open Claude Is Open-source coding-agent CLI for OpenAI, Gemini, DeepSeek, Ollama, Codex, GitHub Models, and 200+ models via OpenAI-compatible APIs.
  * [atmosphere](https://github.com/atmosphere/atmosphere) - Real-time transport layer for Java AI agents. Build once with @Agent — deliver over WebSocket, SSE, gRPC, MCP, A2A, AG-UI, or any transport. Works with Spring AI, LangChain4j, Google ADK, Embabel, Koog or the built-in OpenAI-compatible client.
  * [llm-wiki-agent](https://github.com/samuraigpt/llm-wiki-agent) - A personal knowledge base that builds and maintains itself. Drop in sources — Claude (or Codex/Gemini) reads them, extracts knowledge, and maintains a persistent interlinked wiki. Works with Claude Code, Codex, OpenCode, Gemini CLI. No API key needed.
@@ -2797,5 +2796,4 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
-
 


### PR DESCRIPTION
## Summary

- Add TweetClaw to the CLI resources list.
- Keep the addition README-only, as required by the contribution guide.
- Remove 2 stale organization URLs that duplicate canonical CLI entries.

## Independent Catalogue Fix

GitHub resolves each stale URL to an entry already present in the same section:

- `mote-software/nanocoder` and `Nano-Collective/nanocoder` share repository ID `1029049168`.
- `antinomyhq/forgecode` and `tailcallhq/forgecode` share repository ID `900461318`.

The PR removes only the stale redirect aliases. Both canonical entries remain.

## Validation

- Confirmed TweetClaw is public, active, MIT-licensed, and OpenClaw-focused.
- Confirmed each redirect pair through GitHub's repository API.
- Confirmed TweetClaw and both canonical entries appear exactly once.
- Confirmed no open issue or PR already handles either duplicate.
- Ran `git diff --check`.
- Verified the fork owner is `kriptoburak`.
