### PR TITLE
Add Explyt AI Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2784,5 +2784,5 @@ _Updated on July 06, 2026_ (A total of 2645 repositories listed.)
  * [clawd-on-desk](https://github.com/rullerzhou-afk/clawd-on-desk) - A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents — so you don't have to.
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
-
+ * [Explyt](https://github.com/explyt/explyt) - AI agent for JetBrains IDEs that uses LLMs (Claude, GPT) and fixes code with the project facts your IDE already knows.
 


### PR DESCRIPTION
Add Explyt

## Body

I added Explyt as a single entry at the end of the **Others** section, matching the existing format in README.md.

Explyt is an AI agent for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, Rider, GoLand, etc.) that uses LLMs such as ChatGPT, but grounds them in facts the IDE already knows — project structure, symbol references, connected library sources, static analysis, and live debugger state — instead of relying only on grep-style text search. It can run configured tests and builds, apply IDE refactorings (e.g. semantic rename), navigate symbol usages, and debug with real variable values and call stacks.

Repo: https://github.com/explyt/explyt
JetBrains Marketplace: https://plugins.jetbrains.com/plugin/27979-explyt-ai-agent (7000+ downloads)

## Compliance with contributing.md

- [x] Format: `* [name](url) - description`
- [x] Description concise
- [x] Added to README.md only
- [x] Placed in Others (no dedicated JetBrains/IDE-plugin section exists)

Thanks for maintaining this list!
