### PR TITLE
Add GoodMemory to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,7 @@ _Updated on July 06, 2026_ (A total of 2645 repositories listed.)
  * [cc-connect](https://github.com/chenhg5/cc-connect) - Bridge local AI coding agents (Claude Code, Cursor, Gemini CLI, Codex) to messaging platforms (Feishu/Lark, DingTalk, Slack, Telegram, Discord, LINE, WeChat Work). Chat with your AI dev assistant from anywhere — no public IP required for most platforms.
  * [gptme](https://github.com/erikbjare/gptme) - Chat with LLMs equipped with local tools: executes python and bash, edits local files, browses the web.
  * [TokenTracker](https://github.com/mm7894215/tokentracker) - Track token usage across 25 AI coding tools — Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, Antigravity, Copilot, Kimi, CodeBuddy, WorkBuddy, Grok, Kilo, Roo, Zed, Goose, Mimo, ZCode & more — local-first, zero-config, with a dashboard, macOS menu bar app, and desktop widgets.
+ * [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex and Claude Code, with one-command setup, scoped SQLite recall, read-only MCP, and reversible governed writeback.
 
 
 ## Reimplementations


### PR DESCRIPTION
## Summary

- add GoodMemory to the `CLIs` section
- describe its local-first, scoped memory path for Codex and Claude Code

GoodMemory installs through a CLI and provides managed host wiring, SQLite-backed recall, read-only MCP inspection, and opt-in governed writeback. I maintain the submitted project.

Following the repository's recent accepted contribution pattern, this changes only the canonical `README.md`; translated and search surfaces can be regenerated by the maintainer.

## Validation

- `git diff --check`
- confirmed the project URL returns HTTP 200
- confirmed there is no existing GoodMemory entry or open PR
