### PR TITLE
Add ditto to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,7 @@ _Updated on July 06, 2026_ (A total of 2645 repositories listed.)
  * [gptme](https://github.com/erikbjare/gptme) - Chat with LLMs equipped with local tools: executes python and bash, edits local files, browses the web.
  * [TokenTracker](https://github.com/mm7894215/tokentracker) - Track token usage across 25 AI coding tools — Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, Antigravity, Copilot, Kimi, CodeBuddy, WorkBuddy, Grok, Kilo, Roo, Zed, Goose, Mimo, ZCode & more — local-first, zero-config, with a dashboard, macOS menu bar app, and desktop widgets.
  * [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex and Claude Code, with one-command setup, scoped SQLite recall, read-only MCP, and reversible governed writeback.
+ * [ditto](https://github.com/ohad6k/ditto) - Mine local Claude Code and Codex session history into private, evidence-backed profiles that teach agents how you work.
 
 
 ## Reimplementations


### PR DESCRIPTION
## Summary

- add ditto to the `CLIs` section
- describe its private, evidence-backed profile mining for Claude Code and Codex

Ditto mines local coding-agent session history into a compact profile of how the operator works. I maintain the submitted project.

Following the repository's recent accepted contribution pattern, this changes only the canonical `README.md`; translated and search surfaces can be regenerated by the maintainer.

## Validation

- `git diff --check`
- confirmed the project repository is public, active, and MIT-licensed
- confirmed there is no existing Ditto entry or open PR