### PR TITLE
Add Orkas to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
+ * [Orkas](https://github.com/Orkas-AI/Orkas) - Open-source, local-first desktop workspace that coordinates specialist agents and runs Codex, Claude Code, OpenCode, and Cline from one chat. [Website](https://orkas.ai?source=gh_chatgpt).
 
 
 ## Reimplementations
@@ -2797,5 +2798,4 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
-
 


### PR DESCRIPTION
## Summary\n\nAdd Orkas to the CLIs section.\n\nOrkas is an open-source, local-first desktop workspace that coordinates specialist agents and runs Codex, Claude Code, OpenCode, and Cline from one chat.\n\nProject: https://github.com/Orkas-AI/Orkas\nWebsite: https://orkas.ai?source=gh_chatgpt