### PR TITLE
Add whatbroke to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
+ * [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff an AI agent's behavior between two runs: tool calls added, dropped or reordered, argument changes, cost and latency deltas. Imports OTLP, Langfuse and LangSmith traces, runs entirely locally.
 
 
 ## Reimplementations


### PR DESCRIPTION
CLIs セクションに whatbroke を追加しました。

自作の TypeScript 製 CLI です。AI エージェントの2回の実行を比較して、ツール呼び出しの追加・削除・順序変更、引数の変化、コストとレイテンシの差分を表示します。複数サンプルで実行すると発生率が出て、ベースラインの時点で既に不安定な項目は重要度を下げます。v0.3.0 から OTLP JSON (OTel GenAI semconv)、Langfuse、LangSmith のエクスポートを取り込めるようになったので、既にトレースしているエージェントならコード変更なしで比較できます。処理はすべてローカルで完結します。MIT ライセンスです。

最近マージされた PR の慣例に合わせて、変更は README.md の1行のみです。