### PR TITLE
Add DevProjex to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,7 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
- * [DevProjex](https://github.com/Avazbek22/DevProjex) - Builds structured, token-counted codebase context through a GUI and CLI with file selection, Smart Ignore, preview, and multi-format export.
+ * [DevProjex](https://github.com/Avazbek22/DevProjex) - Provides a scriptable CLI for inspecting, filtering, redacting, compressing, and exporting token-efficient codebase context, alongside GUI, TUI, and read-only MCP workflows.
 
 
 ## Reimplementations

--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
+ * [DevProjex](https://github.com/Avazbek22/DevProjex) - Builds structured, token-counted codebase context through a GUI and CLI with file selection, Smart Ignore, preview, and multi-format export.
 
 
 ## Reimplementations


### PR DESCRIPTION
Adds DevProjex to CLIs as a scriptable CLI for inspecting, filtering, redacting, compressing, and exporting token-efficient codebase context, alongside GUI, TUI, and read-only MCP workflows.