### PR TITLE
Add Unified AI System to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
+ * [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first, self-hosted AI gateway with a Codex plugin and eight-tool MCP server for model routing, knowledge, workflows, workforce inspection, and credential-free local demos.
 
 
 ## Reimplementations

--- a/README.md
+++ b/README.md
@@ -1287,7 +1287,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-profiles](https://github.com/ducksss/codex-profiles) - Named CODEX_HOME profiles and ChatGPT Desktop windows with separate local state, without copying tokens
  * [shob](https://github.com/shobcoder/shob) - Shob – an AI agent that delivers high-quality coding & automation work
  * [nika](https://github.com/supernovae-st/nika) - Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋
- * [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first, self-hosted AI gateway with a Codex plugin and eight-tool MCP server for model routing, knowledge, workflows, workforce inspection, and credential-free local demos.
+ * [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first, self-hosted AI gateway with a Codex plugin and nine MCP tools for provider-free prompt enhancement, health, knowledge, workflows, workforce inspection, and credential-free local demos.
 
 
 ## Reimplementations


### PR DESCRIPTION
## Summary

- add Unified AI System to the `CLIs` section
- describe its terminal-first Codex plugin and current nine-tool MCP gateway surface
- highlight deterministic provider-free prompt enhancement and credential-free local verification

Unified AI System is a public Apache-2.0 project with a terminal CLI, Codex plugin, nine MCP tools, and a credential-free local demo that uses a fake provider by default.

Current release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.0

Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.0

Disclosure: I maintain the submitted project.

Following the repository's recent accepted contribution pattern, this changes only the canonical `README.md`; generated and localized data can remain maintainer-owned.

## Validation

- `git diff --check`
- confirmed there is no existing Unified AI System entry or open PR
- confirmed the project is public, not archived, and Apache-2.0 licensed
- confirmed the submitted source commit passes its public checkout verifier