### PR TITLE
Add Wenyan - open-source Android relationship-decision assistant (BYOK LLM client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2797,5 +2797,6 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
+ * [wenyan](https://github.com/moondrop12138/wenyan) - Wenyan (温言): an open-source Android relationship-decision assistant that connects to your own LLM API keys (OpenAI-compatible, BYOK) - four-section structured analysis (empathy, facts, advice, actions), screenshot analysis with multi-image support, built-in 40-doc offline knowledge base, crisis referral, fully local & private.
 
 


### PR DESCRIPTION
## What

Adds [Wenyan (温言)](https://github.com/moondrop12138/wenyan) to the Others section.

## About the app

An open-source Android LLM client for relationship decision support. Users bring their own API keys (BYOK, any OpenAI-compatible endpoint, including local servers like LM Studio). The app produces four-section structured analysis (empathy → facts → advice with 3 style phrasings → actions), supports screenshot analysis (up to 10 images per request), bundles a 40-doc offline knowledge base with crisis referral (domestic violence / stalking / self-harm), and keeps all data on-device (Keystore AES-GCM encrypted keys, no backend).

- 380+ unit tests, CI on GitHub Actions
- Built with Kotlin + Jetpack Compose; SSE streaming with retry; Room/DataStore local storage
- License: PolyForm Noncommercial 1.0.0 (knowledge base derived from the open-source goutoujunshi project)

Thanks for maintaining this list!