### PR TITLE
Add dochost-mcp to Openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -2318,6 +2318,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux) - Run OpenAI Codex Desktop on Linux - automated installer
  * [Friday](https://github.com/thesongzhu/friday) - AI personal operations platform for supervised, evidence-backed automation.
  * [gpt_image_playground](https://github.com/cooksleep/gpt_image_playground) - 基于 OpenAI gpt-image-2 API 的图片生成与编辑工具
+ * [dochost-mcp](https://github.com/zyli5313/dochost-mcp) - Remote MCP server that publishes Markdown or HTML from ChatGPT to a public shareable link, over Streamable HTTP with OAuth and no API keys.
 
 
 ## Others


### PR DESCRIPTION
Adds [dochost-mcp](https://github.com/zyli5313/dochost-mcp) to **Openai**.

A remote MCP server that publishes Markdown or HTML from ChatGPT to a public, shareable link — the step between "ChatGPT wrote a document" and "someone who is not in the chat can read it." Streamable HTTP with OAuth, no API keys.

`claude mcp add --transport http dochost https://dochost.io/api/mcp`

**Why Openai rather than Browser-extensions:** the browser extension's source is not public, and this list is for open-source repositories, so only the MCP server repo is eligible. Happy to move the entry if you would prefer a different section.

Guidelines followed: link format `* [project-name](url) - Short description ends with a period.`, description kept short, README.md only.

Disclosure: I maintain this repository.