### PR TITLE
Add ThoughtDAG to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,7 @@ _Updated on July 21, 2026_ (A total of 2654 repositories listed.)
  * [CrustAI](https://github.com/davesimoes/crustai) - Private, local-first AI assistant with Telegram, Discord, WhatsApp and Slack
  * [vellum-assistant](https://github.com/vellum-ai/vellum-assistant) - An AI Assistant that’s easy to setup, does your work 24/7, knows your preferences and gets better over time.
  * [hope-agent](https://github.com/shiwenwen/hope-agent) - 🦭跨端交接、越用越懂你的桌面 AI 助手——也能服务化常驻、跑在云上 | Desktop AI that hands off across your devices and gets to know you better — also runs headless on a NAS or in the cloud
+ * [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - A local-first visual LLM workspace where graph edges define the context sent to each model request.
 
 
 ## Browser-extensions


### PR DESCRIPTION
## Summary

Add ThoughtDAG to the `Chatbots` section.

ThoughtDAG is an MIT-licensed visual LLM workspace where graph edges determine the actual conversation and document context sent to each request. It supports OpenAI-compatible endpoints and local models.

Disclosure: I maintain ThoughtDAG.

## Validation

- Confirmed the change is one README entry
- Confirmed there is no existing ThoughtDAG entry or open PR