### PR TITLE
Add Atomic Agent to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) - Control Gmail, Google Calendar, Docs, Sheets, Slides, Chat, Forms, Tasks, Search & Drive with AI - Comprehensive Google Workspace MCP Server & CLI Tool
  * [Chat2DB](https://github.com/ottermind/chat2db) - 🔥🔥🔥 AI-driven database tool and SQL client, The hottest GUI client, supporting MySQL, Oracle, PostgreSQL, DB2, SQL Server, DB2, SQLite, H2, ClickHouse, and more.
  * [opencodex](https://github.com/lidge-jun/opencodex) - Universal provider proxy for OpenAI Codex & Claude Code — use any LLM (Claude, Gemini, Grok, DeepSeek, Ollama…) with Codex CLI, App, SDK, and Claude Code
+ * [atomic-agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine, with 56 built-in tools and MCP support. No account or API key required.
 
 
 ## Reimplementations


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thank you for maintaining this list, it's a genuinely useful map of the ChatGPT and LLM tooling ecosystem, and our team would be thrilled to be part of it.

I added one line to the **CLIs** section, following the format in contributing.md and matching the existing entries there.

**What it is:** Atomic Agent is a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, so there's no account or API key required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP (Model Context Protocol), has a five-layer local memory system, and works on macOS, Linux, and Windows. The TUI is built on React and ink.

**Repo:** https://github.com/AtomicBot-ai/atomic-agent (MIT license, ~2k stars, active)

A few more links in case they're useful:
- Website: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

One note in the spirit of full transparency: the project is about four months old, but it's active (~2k stars) and maintained by the AtomicBot-ai organization, which ships several established projects. Install is a one-liner: `curl -fsSL https://atomicagent.io/install | sh`

Thanks again for the great work on this list. Happy to adjust the wording or placement if you'd prefer something different.
