### PR TITLE
Add Mac Developer Bridge to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [Chat2DB](https://github.com/ottermind/chat2db) - 🔥🔥🔥 AI-driven database tool and SQL client, The hottest GUI client, supporting MySQL, Oracle, PostgreSQL, DB2, SQL Server, DB2, SQLite, H2, ClickHouse, and more.
  * [opencodex](https://github.com/lidge-jun/opencodex) - Universal provider proxy for OpenAI Codex & Claude Code — use any LLM (Claude, Gemini, Grok, DeepSeek, Ollama…) with Codex CLI, App, SDK, and Claude Code
  * [llm-wiki-cli](https://github.com/JanYork/llm-wiki-cli) - Agent-driven proactive memory CLI for Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and other AI agents, with source-grounded Wiki memory, citations, full-text retrieval, optional document/code graphs, and a read-only MCP server.
+ * [mac-developer-bridge](https://github.com/alexanderradahl/mac-developer-bridge) - Let ChatGPT operate your actual Mac via MCP with shell, files, real PTYs, background jobs, and read-only Codex history.
 
 
 ## Reimplementations


### PR DESCRIPTION
Adds [Mac Developer Bridge](https://github.com/alexanderradahl/mac-developer-bridge) to the CLIs section.

It is an MIT-licensed macOS MCP bridge that lets ChatGPT use local shell/files/PTY sessions/background jobs and read-only Codex history. The description is intentionally short and only README.md is changed, following the contribution guidelines.