### PR TITLE
Add gpt-daichong to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,7 +1377,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [ai-cookbook](https://github.com/daveebbelaar/ai-cookbook) - Examples and tutorials to help developers build AI systems
  * [easy-vibe](https://github.com/datawhalechina/easy-vibe) - Learn vibe coding from 0 to 1 | 实战中从零学会 AI 编程｜产品思维、前后端开发
  * [RAG_Techniques](https://github.com/nirdiamant/rag_techniques) - This repository showcases various advanced techniques for Retrieval-Augmented Generation (RAG) systems. Each technique has a detailed notebook tutorial.
-
+ * [gpt-daichong](https://github.com/momochoog/gpt-daichong) - Chinese operator-maintained guide to ChatGPT Plus and Pro subscriptions, covering domestic payment options, Plus vs. Pro 5x/20x, order lookup, and credential-safety boundaries.
 
 ## NLP
 


### PR DESCRIPTION
## Summary

- Add `gpt-daichong` to the Tutorials catalog.
- Describe its Chinese guide to ChatGPT Plus / Pro selection, domestic payment options, order lookup, and credential-safety boundaries.

Project: https://github.com/momochoog/gpt-daichong

Disclosure: I maintain this repository and participate in AIXiamo operations. The guide includes clearly labeled first-party service information; this submission is not an independent review or an OpenAI-official resource.

## Scope and validation

- README only
- One concise Tutorials entry
- Confirmed the canonical repository URL resolves
- Confirmed there is no existing `gpt-daichong` entry or open pull request