### PR TITLE
Add UIZZE anti-UI-slop toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2343,6 +2343,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
 
 ## Others
 
+ * [UIZZE](https://github.com/uizze/uizze) - Anti-UI-slop skills and a free MCP preview for Codex, Claude Code, Cursor, and Copilot, grounded in 800,000+ real web and iOS screens.
  * [visual-chatgpt](https://github.com/microsoft/visual-chatgpt) - Official repo for the paper: Visual ChatGPT: Talking, Drawing and Editing with Visual Foundation Models
  * [nanoGPT](https://github.com/karpathy/nanogpt) - The simplest, fastest repository for training/finetuning medium-sized GPTs.
  * [gpt_index](https://github.com/jerryjliu/gpt_index) - Tensors and Dynamic neural networks in Python  with strong GPU acceleration
@@ -2818,5 +2819,4 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
-
 


### PR DESCRIPTION
Adds UIZZE to the Others section as a practical UI-quality tool for coding agents.

- anti-UI-slop skills for Codex, Claude Code, Cursor, and Copilot
- free MCP preview
- grounded in 800,000+ real web and iOS screens

Project: https://github.com/uizze/uizze
Website: https://uizze.com