### PR TITLE
Add awesome-agentic-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only.
  * [ai-models](https://github.com/i-need-token/ai-models) - Structured YAML catalog of 4,587 AI models across 95 providers — pricing, context windows, modalities, capabilities. First-party data with TypeScript types and Zod validation.
  * [awesome-gpt-image-2](https://github.com/youmind-openlab/awesome-gpt-image-2) - 🚀 World's largest GPT Image 2 prompt library, updated daily — 2000+ curated prompts with preview images, 16 languages. OpenAI's next-gen image model with pixel-perfect text rendering, cross-image consistency, and commercial-grade illustration. Free & open source.
+ * [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Curated hub of Codex, Claude, and Cursor agent skills, notebooks, and papers for building with coding LLMs.
 
 
 ## Prompts


### PR DESCRIPTION
Adds https://github.com/adriannoes/awesome-agentic-ai to **Awesome-lists**.

Your catalog covers ChatGPT/Codex-era repos; this hub indexes maintained skills, prompts, and learning material for Claude Code, OpenAI Codex, and Cursor — a meta-list in the same spirit as the other awesome-* entries here.

MIT. Public. One link at the bottom of the section.