### PR TITLE
Add Chat Threads to Browser-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
  * [oh-my-taiyiforge](https://github.com/dong90/oh-my-taiyiforge) - AI workflow automation plugin for intelligent code generation with Claude/Codex
  * [explyt](https://github.com/explyt/explyt) - AI agent for JetBrains IDEs: debugger, refactorings, and symbol navigation via IDE — fewer tokens, more precision
  * [voyager](https://github.com/nagi-ovo/voyager) - 面向 AI Studio、Gemini、Claude 与 ChatGPT 的全能增强套件。
+ * [chat-threads](https://github.com/onyourmark/chat-threads) - Side panel that cleans a long ChatGPT or Claude conversation and splits it into separate topic conversations, working on a copy so the original is untouched.
 
 
 ## CLIs


### PR DESCRIPTION
Adding [Chat Threads](https://github.com/onyourmark/chat-threads) to the Browser-extensions section.

It is an open-source (MIT) Chrome and Edge side panel for reshaping a long ChatGPT or Claude conversation: read back only your own prompts, exclude or edit individual turns, and split one conversation into separate topic conversations you can paste into a new chat.

It works on a copy — it issues read requests only, so the original ChatGPT or Claude conversation is never modified.

No backend, no account, no analytics, and no host permissions at install time (it uses `activeTab`, so it can only read the tab after you click its toolbar icon). An optional Find Topics feature can ask OpenAI or Anthropic to propose the split using the user's own API key; everything else works with no key and makes no network requests.

TypeScript, MV3, 348 tests. Not affiliated with OpenAI or Anthropic.

One line added at the end of the section, following contributing.md.