### PR TITLE
Add verified-memory-vault to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -2344,6 +2344,7 @@ _Updated on August 10, 2026_ (A total of 2664 repositories listed.)
 
 ## Others
 
+ * [verified-memory-vault](https://github.com/secondbrainstarter/verified-memory-vault) - A self-checking Obsidian vault that gives AI coding agents persistent memory: `memory_check.py` scores the memory's health (dead links, bloat, protocol violations), and an optional git hook refuses commits that delete it.
  * [UIZZE](https://github.com/uizze/uizze) - Anti-UI-slop skills and a free MCP preview for Codex, Claude Code, Cursor, and Copilot, grounded in 800,000+ real web and iOS screens.
  * [visual-chatgpt](https://github.com/microsoft/visual-chatgpt) - Official repo for the paper: Visual ChatGPT: Talking, Drawing and Editing with Visual Foundation Models
  * [nanoGPT](https://github.com/karpathy/nanogpt) - The simplest, fastest repository for training/finetuning medium-sized GPTs.


### PR DESCRIPTION
Adds [verified-memory-vault](https://github.com/secondbrainstarter/verified-memory-vault) to the **Others** section.

A self-checking Obsidian vault that gives AI coding agents (Claude Code, Codex, Gemini CLI, …) persistent memory: `memory_check.py` scores the memory's health at any time (protocol violations, dead links, bloat), and an optional git pre-commit hook (`memory_guard.py`) refuses commits that mass-delete the memory files. Dependency-free Python, MIT-licensed tools, CC BY 4.0 vault content.

Format followed per `contributing.md`: one bullet line in `README.md` with a short description ending in a period.