### PR TITLE
Add vidwords-mcp to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -2829,5 +2829,6 @@ _Updated on August 27, 2026_ (A total of 2675 repositories listed.)
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
  * [uizze](https://github.com/uizze/uizze) - Four free UI skills, focused UIZZE MCP references, and a conservative GitHub Action for coding agents.
+ * [vidwords-mcp](https://github.com/haljishi/vidwords-mcp) - Hosted YouTube MCP server for ChatGPT, Claude and Cursor - searches transcripts across a channel, reads captions, and analyses a video's frames, returning citable timestamps.
 
 


### PR DESCRIPTION
### What this adds

One line at the end of **Others**:

```
 * [vidwords-mcp](https://github.com/haljishi/vidwords-mcp) - Hosted YouTube MCP server for ChatGPT, Claude and Cursor - searches transcripts across a channel, reads captions, and analyses a video's frames, returning citable timestamps.
```

### About the project

`haljishi/vidwords-mcp` is the public repo for a hosted MCP server: README with the nine tools, `server.json`, client configs for Claude Desktop, Claude Code, Cursor and Codex, and an agent skill.

- Endpoint: `https://vidwords.com/mcp` — remote Streamable HTTP
- Auth: OAuth 2.1 (DCR + PKCE), so ChatGPT and Claude connect with nothing typed; a static token also works for headless agents
- Official MCP registry: `com.vidwords/youtube`, `status: active`
- License: MIT

### Notes

- Checked the Table of contents first; there is no MCP or video section, so per `contributing.md` this goes in **Others**.
- Format follows the surrounding rows and the diff style of the recently merged entries: one line, short description.
- I left the stats table alone, as recent merged PRs do.

### Disclosure

I maintain this project.
