### PR TITLE
Refresh UIZZE directory description

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Run these two commands inside Claude Code:
 
 
 **Others**
- * [uizze](https://github.com/uizze/uizze) - Four free UI skills, focused UIZZE MCP references, and a conservative GitHub Action for coding agents.
+ * [uizze](https://github.com/uizze/uizze) - Three free UI skills and a remote MCP server for coding agents, grounded in 800,000+ real Web and iOS screens, plus a conservative GitHub Action.
 
 
 _Updated on August 27, 2026_ (A total of 2675 repositories listed.)
@@ -2828,6 +2828,4 @@ _Updated on August 27, 2026_ (A total of 2675 repositories listed.)
  * [ping-island](https://github.com/erha19/ping-island) - A Dynamic Island-style command center for managing all your AI coding agents on macOS.
  * [PriceAI](https://github.com/dimthink/priceai) - AI 订阅卡网渠道比价工具：聚合100+卡网渠道包含 ChatGPT、Claude、Gemini、Grok 等多渠道报价，展示有货最低价、库存状态和原站购买链接。
  * [GoodMemory](https://github.com/hjqcan/goodmemory) - Local-first, auditable memory layer for AI apps and coding agents — Codex, Claude Code, MCP, HTTP, TypeScript, and Python.
- * [uizze](https://github.com/uizze/uizze) - Four free UI skills, focused UIZZE MCP references, and a conservative GitHub Action for coding agents.
-
-
+ * [uizze](https://github.com/uizze/uizze) - Three free UI skills and a remote MCP server for coding agents, grounded in 800,000+ real Web and iOS screens, plus a conservative GitHub Action.


### PR DESCRIPTION
## Summary

This keeps the existing UIZZE placement and corrects its current description in the two README occurrences.

- Removes the outdated four-skill wording. The fourth listed route returns 404; three public Skill endpoints are currently live.
- Names the remote MCP server and the 800,000+ real Web and iOS screens that ground the product.
- Keeps the existing canonical GitHub URL and conservative GitHub Action reference.
- Changes README.md only, as requested by contributing.md. No new listing is added.

Verified the live Skill endpoints and ran git diff --check.

This PR was prepared with AI assistance and reviewed by the contributor before submission.