### PR TITLE
Add chatgpt-to-word-template to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,6 +1382,7 @@ _Updated on August 27, 2026_ (A total of 2675 repositories listed.)
  * [ai-cookbook](https://github.com/daveebbelaar/ai-cookbook) - Examples and tutorials to help developers build AI systems
  * [easy-vibe](https://github.com/datawhalechina/easy-vibe) - Learn vibe coding from 0 to 1 | 实战中从零学会 AI 编程｜产品思维、前后端开发
  * [RAG_Techniques](https://github.com/nirdiamant/rag_techniques) - This repository showcases various advanced techniques for Retrieval-Augmented Generation (RAG) systems. Each technique has a detailed notebook tutorial.
+ * [chatgpt-to-word-template](https://github.com/loebpaul/chatgpt-to-word-template) - Free checklists and an example workflow for turning ChatGPT output into an editable Word document.
 
 
 ## NLP


### PR DESCRIPTION
Adds a free ChatGPT-to-Word workflow repository to the Tutorials section. It includes a ready-to-edit Word starter, a response-preparation checklist, a Word-template readiness checklist, and a structured example draft for reviewing the resulting editable DOCX.

Disclosure: I maintain the repository through BrandQuill. The repository and its included resources are free under the MIT license. It links to an optional browser-based publisher, but the tutorial does not require a purchase.