### PR TITLE
Add FutureOS to CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Run these two commands inside Claude Code:
 ## The latest additions 🎉
 
 **CLIs**
+ * [FutureOS](https://github.com/futuregene/future-os) - One AI agent everywhere: terminal UI, desktop, mobile, CLI, and IM bots from one Rust backend. Approval-gated tools, 3,800+ models.
  * [zero](https://github.com/gitlawb/zero) - The coding agent that answers to you, your model, your machine, your rules.
  * [PDFMathTranslate](https://github.com/pdfmathtranslate/pdfmathtranslate) - [EMNLP 2025 Demo] PDF scientific paper translation with preserved formats - 基于 AI 完整保留排版的 PDF 文档全文双语翻译，支持 Google/DeepL/Ollama/OpenAI 等服务，提供 CLI/GUI/MCP/Docker/Zotero
 
@@ -1030,6 +1031,7 @@ _Updated on August 31, 2026_ (A total of 2680 repositories listed.)
 
 ## CLIs
 
+ * [FutureOS](https://github.com/futuregene/future-os) - One AI agent everywhere: a single Rust backend drives terminal UI, desktop, mobile, CLI, and IM bots with the same sessions, memory, and skills. Trust-first approval-gated tools, 3,800+ models, loop control plane for 24h+ runs.
  * [ChatGPT](https://github.com/acheong08/chatgpt) - Reverse engineered ChatGPT API
  * [shell_gpt](https://github.com/ther1d/shell_gpt) - A command-line productivity tool powered by ChatGPT, will help you accomplish your tasks faster and more efficiently.
  * [PyChatGPT](https://github.com/rawandahmad698/pychatgpt) - ⚡️ Python client for the unofficial ChatGPT API with auto token regeneration, conversation tracking, proxy support and more.


### PR DESCRIPTION
Adds [FutureOS](https://github.com/futuregene/future-os) to the **CLIs** section (top of list) and to **The latest additions 🎉**.

FutureOS is one AI agent everywhere: a single Rust backend drives terminal UI, desktop, mobile, CLI, and IM bots with the same sessions, memory, and skills. Trust-first approval-gated tools, 3,800+ models, loop control plane for 24h+ runs.