### PR TITLE
Add OrcaReplay to Openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -2348,6 +2348,7 @@ _Updated on September 07, 2026_ (A total of 2689 repositories listed.)
  * [pr-agent](https://github.com/the-pr-agent/pr-agent) - 🚀 PR Agent: The Original Open-Source PR Reviewer. This project is not the Qodo free tier.
  * [FunASR](https://github.com/modelscope/funasr) - Open-source speech recognition toolkit for training, inference, streaming ASR, VAD, punctuation, speaker diarization pipelines, and OpenAI-compatible/MCP serving.
  * [watermarks-remover](https://github.com/guillaumemeyer/watermarks-remover) - A privacy-first app that strips AI watermarks from content you own.
+ * [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a Codex CLI or other coding-agent run below the harness and replays it offline, or forks it onto another model.
 
 
 ## Others


### PR DESCRIPTION
Adds OrcaReplay to **Openai**.

It records a coding-agent run below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The recording then replays offline with the network off, or forks from a chosen checkpoint onto a different model.

**Why the Openai section.** Codex CLI is a first-class target: with an API key it records through `OPENAI_BASE_URL` against the Responses API, and a ChatGPT-subscription login is handled too — that mode talks only to OpenAI's own backend with no base URL to redirect, so orca recognises the `/backend-api/codex/responses` fallback and decodes its zstd request bodies to match. The section already carries several Codex-adjacent entries (`codex-lb`, `codex-desktop-linux`), so this seemed the right home; happy to move it to `Others` if you read the scope differently.

Format follows the guidelines: `* [project-name](url) - A short description ends with a period.`, added to README.md only. There is no stats table in this section, so nothing else to update.

Apache-2.0, TypeScript, on npm as `orcareplay` (Node 20+). The repository is nine days old with 150 stars.
